### PR TITLE
Fix missing include for non-unity builds

### DIFF
--- a/CircularDependenciesDetector/Source/CircularDependenciesDetector/Private/Copy_ApplicationRestartRequiredNotification.h
+++ b/CircularDependenciesDetector/Source/CircularDependenciesDetector/Private/Copy_ApplicationRestartRequiredNotification.h
@@ -1,7 +1,10 @@
 // Copyright 2022 bstt, Inc. All Rights Reserved.
 
+#pragma once
+
 #include "Framework/Notifications/NotificationManager.h"
 #include "Widgets/Notifications/SNotificationList.h"
+#include "UnrealEdMisc.h"
 
 // code taken from Developer/SettingsEditor/Private/SettingsEditorModule.cpp
 


### PR DESCRIPTION
When building a game with this plugin in non-unity mode the compilation fails with
```
In file included from ../../Game/Plugins/CircularDependenciesDetector/Source/CircularDependenciesDetector/Private/Config/CDD_Settings.cpp:6:
<ProjectPath>\Game\Plugins\CircularDependenciesDetector\Source\CircularDependenciesDetector\Private\Copy_ApplicationRestartRequiredNotification.h(65,3): error: use of undeclared identifier 'FUnrealEdMisc'
                FUnrealEdMisc::Get().RestartEditor(false);
                ^
1 error generated.
```

This is due to a missing include for `UnrealEdMisc.h` in `Copy_ApplicationRestartRequiredNotification.h`.

Additionally there is no `#pragma once` include guard at the beginning of the file.

Fixed both.

_Note:_
The include error does not occur when building in unity mode.